### PR TITLE
[Chore/Hotfix] Bug fixes for backend ORM implementations

### DIFF
--- a/src/components/Actions/ReceiptActions.tsx
+++ b/src/components/Actions/ReceiptActions.tsx
@@ -14,18 +14,10 @@ import RejectReceiptStatus from "@/components/Modals/RejectReceiptsModal";
 interface ReceiptProps {
   receipt_id: number;
   disabled: boolean;
-  onApprove: (id: number) => void;
-  onReject: (id: number) => void;
   token: string;
 }
 
-export default function ReceiptActions({
-  receipt_id,
-  disabled,
-  onApprove,
-  onReject,
-  token,
-}: ReceiptProps) {
+export default function ReceiptActions({ receipt_id, disabled, token }: ReceiptProps) {
   const [showModal, setShowModal] = useState(false);
   const [action, setAction] = useState<"approve" | "reject" | null>(null);
   const [loading, setLoading] = useState(false);
@@ -46,8 +38,7 @@ export default function ReceiptActions({
    * @returns {Promise<void>}
    */
   const confirmAction = async () => {
-    // Convert action to approval value: 1 for approve, 0 for reject
-    const approval = action === "approve" ? 1 : 0;
+    const approval = action === "approve" ? "Aprobado" : "Rechazado";
 
     try {
       setLoading(true);
@@ -67,7 +58,7 @@ export default function ReceiptActions({
 
       // Execute appropriate callback based on action result
       if (res.ok) {
-        approval === 1 ? onApprove(receipt_id) : onReject(receipt_id);
+        alert(`Comprobante ${approval.toLowerCase()} exitosamente.`);
       } else {
         alert(data.error || "No se pudo actualizar.");
       }

--- a/src/components/Forms/CreateAuthRuleForm.tsx
+++ b/src/components/Forms/CreateAuthRuleForm.tsx
@@ -40,7 +40,7 @@ export default function CreateAuthRuleForm({ token, mode, data }: Props) {
       setAutomatico(data.automatic || false);
       setAutorizadores(data.levels?.map((n: any) => n.level_type) || []);
       setIsSuperiorSelected(
-        data.levels?.map((n: any) => n.superior_level_number !== null) || []
+        data.levels?.map((n: any) => n.level_type === "Nivel_Superior") || []
       );
       setSelectedLevels(
         data.levels?.map((n: any) => n.superior_level_number || null) || []
@@ -81,11 +81,11 @@ export default function CreateAuthRuleForm({ token, mode, data }: Props) {
 
     setIsSuperiorSelected((prev) => {
       const next = [...prev];
-      next[index] = value === "Nivel Superior";
+      next[index] = value === "Nivel_Superior";
       return next;
     });
 
-    if (value !== "Nivel Superior") {
+    if (value !== "Nivel_Superior") {
       setSelectedLevels((prev) => {
         const next = [...prev];
         next[index] = "";
@@ -120,7 +120,7 @@ export default function CreateAuthRuleForm({ token, mode, data }: Props) {
       max_duration: Number(diasMax),
       min_amount: Number(montoMin),
       max_amount: Number(montoMax),
-      niveles: autorizadores.map((type, index) => ({
+      levels: autorizadores.map((type, index) => ({
         level_number: index + 1,
         level_type: type,
         superior_level_number: isSuperiorSelected[index] ? selectedLevels[index] : null,
@@ -192,7 +192,7 @@ export default function CreateAuthRuleForm({ token, mode, data }: Props) {
         </div>
         {niveles > 0 && niveles < 11 && (
           <div className="flex flex-col card-secondary mt-4">
-            <div className="flex flex-col gap-4 md:w-1/2">
+            <div className="flex flex-col gap-4">
               <h3 className="font-semibold text-text-primary">Autorizadores por nivel</h3>
               <div className="flex flex-col gap-1">
                 <Checkbox
@@ -230,7 +230,7 @@ export default function CreateAuthRuleForm({ token, mode, data }: Props) {
                         <option value="">Selecciona un autorizador</option>
                         <option value="Jefe">Jefe Directo</option>
                         <option value="Aleatorio">Autorizador Aleatorio</option>
-                        <option value="Nivel Superior">Nivel Superior</option>
+                        <option value="Nivel_Superior">Nivel Superior</option>
                       </Select>
                       {isSuperiorSelected[index] && (
                         <Select

--- a/src/components/Forms/DefaultAuthRule.tsx
+++ b/src/components/Forms/DefaultAuthRule.tsx
@@ -48,7 +48,7 @@ export default function DefaultAuthRule({ defaultRule, token }: Props) {
       // If there is a config for this level, set array values
       if (nivelConfig) {
         nextAutorizadores[i] = nivelConfig.level_type || "";
-        const isSuperior = nivelConfig.level_type === "Nivel Superior";
+        const isSuperior = nivelConfig.level_type === "Nivel_Superior";
         nextIsSuperiorSelected[i] = isSuperior;
         nextSelectedLevels[i] = isSuperior ? (nivelConfig.superior_level_number || "") : "";
       } else {
@@ -96,12 +96,12 @@ export default function DefaultAuthRule({ defaultRule, token }: Props) {
 
     setIsSuperiorSelected(prev => {
       const next = [...prev];
-      next[index] = value === "Nivel Superior";
+      next[index] = value === "Nivel_Superior";
       return next;
     });
 
     // If changing away from "Nivel Superior", clear the selection for that level
-    if (value !== "Nivel Superior") {
+    if (value !== "Nivel_Superior") {
       setSelectedLevels(prev => {
         const next = [...prev];
         next[index] = "";
@@ -144,7 +144,7 @@ export default function DefaultAuthRule({ defaultRule, token }: Props) {
       is_default: true,
       num_levels: niveles,
       automatic: automatico,
-      niveles: autorizadores.map((type, index) => ({
+      levels: autorizadores.map((type, index) => ({
         level_number: index + 1,
         level_type: type,
         superior_level_number: isSuperiorSelected[index] ? selectedLevels[index] : null
@@ -237,7 +237,7 @@ export default function DefaultAuthRule({ defaultRule, token }: Props) {
                         <option value="">Selecciona un autorizador</option>
                         <option value="Jefe">Jefe Directo</option>
                         <option value="Aleatorio">Autorizador Aleatorio</option>
-                        <option value="Nivel Superior">Nivel Superior</option>
+                        <option value="Nivel_Superior">Nivel Superior</option>
                       </Select>
                       {/* If "Superior level" is selected, show level select */}
                       {isSuperiorSelected[index] && (

--- a/src/components/Forms/SubmitTravelExpense.tsx
+++ b/src/components/Forms/SubmitTravelExpense.tsx
@@ -107,7 +107,7 @@ export async function SubmitTravelExpense({
   // Wait for the server to process
   await new Promise((res) => setTimeout(res, 500));
 
-  // If replacing a previous receipt, delete it and reset request status to pending
+  // If replacing a previous receipt, delete it
   if (receiptToReplace) {
     try {
       // Delete the previous receipt
@@ -117,14 +117,8 @@ export async function SubmitTravelExpense({
           Authorization: `Bearer ${token}`,
         },
       });
-
-      // Reset the request status to 6 (Comprobación gastos del viaje) to allow revalidation
-      await apiRequest(`/applicant/update-request-status/${requestId}/6`, {
-        method: "PUT",
-        headers: { Authorization: `Bearer ${token}` },
-      });
     } catch (err) {
-      console.error("Error replacing receipt or updating status:", err);
+      console.error("Error replacing receipt:", err);
       // Don't throw - the new receipt was uploaded successfully
     }
   }

--- a/src/components/Forms/TravelRequestForm.tsx
+++ b/src/components/Forms/TravelRequestForm.tsx
@@ -672,7 +672,6 @@ export default function TravelRequestForm({ data, mode, request_id, user_id, rol
           value={formData.requested_fee === 0 ? '' : formData.requested_fee}
           onChange={handleGeneralChange}
           required
-          error={error ? 'Campo requerido' : ''}
         />
         <Textarea
           name="notes"

--- a/src/components/Modals/AproveReceiptsModal.tsx
+++ b/src/components/Modals/AproveReceiptsModal.tsx
@@ -39,7 +39,7 @@ export default function ApproveReceiptStatus({
       const url = `/accounts-payable/validate-receipt/${receipt_id}`;
       await apiRequest(url, { 
         method: "PUT", 
-        data: {"approval": 1},
+        data: {"approval": "Aprobado"},
         headers: { Authorization: `Bearer ${token}` }
       });
       setToast({ message: 'Comprobante aprobado exitosamente.', type: 'success' });

--- a/src/components/Modals/RejectReceiptsModal.tsx
+++ b/src/components/Modals/RejectReceiptsModal.tsx
@@ -46,7 +46,7 @@ export default function RejectReceiptStatus({
       const url = `/accounts-payable/validate-receipt/${receipt_id}`;
       await apiRequest(url, { 
         method: "PUT", 
-        data: { "approval": 0 },
+        data: { "approval": "Rechazado" },
         headers: { Authorization: `Bearer ${token}` }
       });
       setToast({ message: 'Comprobante rechazado exitosamente.', type: 'success' });

--- a/src/components/RequestsLists/ReceiptsList.tsx
+++ b/src/components/RequestsLists/ReceiptsList.tsx
@@ -102,8 +102,6 @@ export default function ReceiptsList({ expenses, token }: Props) {
                       <ReceiptActions
                         receipt_id={receipt.receipt_id}
                         disabled={false}
-                        onApprove={() => {}} // This was implemented in a wrong way, empty for now
-                        onReject={() => {}}
                         token={token}
                       />
                     )}

--- a/src/views/ApplicantView.astro
+++ b/src/views/ApplicantView.astro
@@ -12,8 +12,7 @@ import { apiRequest } from '@utils/apiClient';
 
 // Color for each request status
 const colorDesign: { [key: string]: string } = {
-  'Primera Revisión': "success",
-  'Segunda Revisión': "alert",
+  'Revisión': "success",
   'Cotización del Viaje': "warning",
   'Atención Agencia de Viajes': "primary",
   'Comprobación gastos del viaje': "secondary",
@@ -73,8 +72,8 @@ const { userName } = Astro.props;
       {requests.length > 0 ? (
         <div class="space-y-6">
           {requests.map((request: any) => {
-            const isEditable = request.status === "Primera Revisión";
-            const isNotCancelable = request.status === "Comprobación gastos del viaje" || request.status === "Validación de comprobantes";
+            const isEditable = request.status === "Revisión";
+            const isNotCancelable = request.status !== "Revisión";
             const mustBeChecked = request.status === "Comprobación gastos del viaje";
             return (
               <Card


### PR DESCRIPTION
<!-- -----------------------------------------------------------------
Pull Request Template

Select the type of PR below and complete the relevant checklist.
------------------------------------------------------------------ -->

# Pull Request Type

Select one (required):

- [ ] **Feature** - New functionality or User Story implementation
- [x] **Chore** - Maintenance, refactoring, docs, or tooling
- [x] **Hotfix** - Critical bug fix for production
- [ ] **Documentation** - Documentation-only changes
- [ ] **Style** - Code formatting or linting with no functional change

---

**Description of feature:**

_What does this PR implement?_

This pull request introduces several improvements and refactors to the receipts and authorization rules components, focusing on standardizing field names and values and cleaning up unused props and logic.

**Standardization and Consistency Improvements:**

* Changed all approval/rejection values sent to the backend from numeric (`1`/`0`) to string values (`"Aprobado"`/`"Rechazado"`) for both approval and rejection actions in receipt validation flows, including in `ReceiptActions`, `ApproveReceiptStatus`, and `RejectReceiptStatus` components.
* Standardized the use of `"Nivel_Superior"` (instead of `"Nivel Superior"`) for level type values throughout authorization rule forms and default rule logic, including all related comparisons, select options, and initializations.

**Field Name Refactoring:**

* Renamed the `niveles` field to `levels` in the payload for both custom and default authorization rule forms to match backend expectations.

**UI/UX and Logic Cleanups:**

* Removed unnecessary `onApprove` and `onReject` props from the `ReceiptActions` component and replaced callback logic with user-facing alerts on approval/rejection.
* Improved status labeling and editability logic in the applicant view by unifying `"Primera Revisión"` and `"Segunda Revisión"` into `"Revisión"` and adjusting related color and cancelation logic.

**Minor Bug Fixes and Cleanups:**

* Removed redundant status reset logic when replacing a receipt in the `SubmitTravelExpense` form, as it is no longer required.

---

## Pre-Submission Checklist (All PRs)

- [x] I have read the [CONTRIBUTING](../../CONTRIBUTING.md) guide
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] PR targets the appropriate branch (`main` on dittravel)
- [x] Code has been tested locally
- [x] No console errors or warnings
