### PR TITLE
[Fix] Prevent null value for national receipt creation and replace invalid CSS selectors for sidebar buttons

### DIFF
--- a/src/components/Buttons/SideBarButton.astro
+++ b/src/components/Buttons/SideBarButton.astro
@@ -20,6 +20,7 @@ const { item, isActive } = Astro.props;
 
 <a
   href={item.route}
+  data-sidebar-path={item.route}
   class={`flex items-center gap-3 px-3 py-2 rounded-lg group bg-card
     transition-all duration-300 ease-in-out
     hover:bg-text-primary/10 hover:translate-x-1

--- a/src/components/Forms/ExpensesForm.tsx
+++ b/src/components/Forms/ExpensesForm.tsx
@@ -73,7 +73,7 @@ export default function ExpensesForm({
     isInternational: data ? data.currency !== "MXN" : false,
     exch_rate: data?.exch_rate
       ? parseFloat(data.exch_rate).toFixed(2).toString()
-      : "",
+      : "1",
   });
 
   // File states
@@ -170,7 +170,7 @@ export default function ExpensesForm({
   // or set to USD if switching to international
   useEffect(() => {
     if (!formData.isInternational && formData.currency !== "MXN") {
-      setFormData((prev) => ({ ...prev, currency: "MXN" }));
+      setFormData((prev) => ({ ...prev, currency: "MXN", exch_rate: "1" }));
     } else if (formData.isInternational && formData.currency === "MXN") {
       setFormData((prev) => ({ ...prev, currency: "USD" }));
       setXmlFile(null);

--- a/src/components/Layout/Sidebar.astro
+++ b/src/components/Layout/Sidebar.astro
@@ -101,7 +101,7 @@ const groupedItems = items.reduce((acc: Record<string, MenuItem[]>, item: MenuIt
 
 <script is:inline>
   const currentPath = window.location.pathname;
-  const activeItem = document.querySelector(`#sidebar-${currentPath}`);
+  const activeItem = document.querySelector(`[data-sidebar-path="${currentPath}"]`);
 
   if (activeItem) {
     const startY = window.scrollY;


### PR DESCRIPTION
…alid CSS selectors for sidebar buttons

<!-- -----------------------------------------------------------------
Pull Request Template

Select the type of PR below and complete the relevant checklist.
------------------------------------------------------------------ -->

# Pull Request Type

Select one (required):

- [ ] **Feature** - New functionality or User Story implementation
- [ ] **Chore** - Maintenance, refactoring, docs, or tooling
- [x] **Hotfix** - Critical bug fix for production
- [ ] **Documentation** - Documentation-only changes
- [ ] **Style** - Code formatting or linting with no functional change

---

**Description of feature:**

_What does this PR implement?_

**Sidebar navigation warning fix:**

* Added a `data-sidebar-path` attribute to sidebar links in `SideBarButton.astro` to prevent console errors for the active sidebar item based on the current path.

**Expenses form exchange rate fix:**

* Changed the default value for the `exch_rate` field in `ExpensesForm.tsx` to `"1"` for national receipts instead of an empty string, ensuring a valid default exchange rate.

---

## Pre-Submission Checklist (All PRs)

- [x] I have read the [CONTRIBUTING](../../CONTRIBUTING.md) guide
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] PR targets the appropriate branch (`main` on dittravel)
- [x] Code has been tested locally
- [x] No console errors or warnings
