### PR TITLE
[Feat] Added preview for employee import with role mapping and example JSON file updated to be downloadable

### DIFF
--- a/src/components/Buttons/ImportDataButton.tsx
+++ b/src/components/Buttons/ImportDataButton.tsx
@@ -5,17 +5,21 @@
 * from a file. When clicked, it triggers a hidden file input that accepts files
 */
 
-import { useState } from "react";
-import Button from "@/components/Buttons/Button";
+import { useState, useRef } from "react";
 import Tag from "@/components/Utils/Tag";
 import Reminder from "@/components/Utils/Reminder";
+import ImportPreview from "@/components/Modals/ImportPreview";
+import Icon from "@/components/Utils/Icon";
 
+// Interfaces for the component props and data structures used in the import process
+
+// Props for the ImportDataButton component
 interface Props {
-  endpoint: string; // API endpoint to send the file for processing
+  endpoint: string;
   token: string;
 }
 
-// Structure of the response expected from the backend after importing data
+// Interface for the response received after importing data
 interface ImportResponse {
   success: boolean;
   message: string;
@@ -40,9 +44,50 @@ interface ImportResponse {
   error?: string;
 }
 
+// Raw data structures for employees, departments, and cost centers as received from the preview endpoint
+interface EmpleadoRaw {
+  NoEmpleado: string;
+  Nombre: string;
+  Usuario: string;
+  Email: string;
+  JefeInmediato: string | null;
+  Proveedor: number;
+  CeCo: number;
+  Departamento: number;
+  Status: string;
+  FechaAlta: string;
+  FechaCambio: string;
+  Rol?: string;
+}
+
+interface DepartamentoRaw {
+  Clave: number;
+  Descripcion: string;
+  CeCo: number;
+}
+
+interface CeCoRaw {
+  Clave: number;
+  Descripcion: string;
+}
+
+// Interface for the parsed import data that will be used in the preview
+interface ParsedImportData {
+  Empleados: EmpleadoRaw[];
+  Departamentos: DepartamentoRaw[];
+  CeCo: CeCoRaw[];
+}
+
+// Props for the SummaryCard component
 interface SummaryCardProps {
   title: string;
   children: React.ReactNode;
+}
+
+interface SummaryItemProps {
+  label: string;
+  items: string[];
+  type: 'success' | 'warning';
 }
 
 /**
@@ -60,12 +105,6 @@ function SummaryCard({ title, children }: SummaryCardProps) {
       <div className="space-y-2">{children}</div>
     </div>
   );
-}
-
-interface SummaryItemProps {
-  label: string;
-  items: string[];
-  type: 'success' | 'warning';
 }
 
 /**
@@ -92,94 +131,142 @@ function SummaryItem({ label, items, type }: SummaryItemProps) {
   );
 }
 
+/**
+ * Import Data Button Component
+ * This component allows administrators to import data from a file.
+ * It handles file selection, previewing the data, and displaying a summary of the import results.
+ * @param {endpoint} - The API endpoint to which the file will be uploaded for import.
+ * @param {token} - The authentication token to be included in the request headers.
+ */
 export default function ImportDataButton({ endpoint, token }: Props) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // States to manage the import process
   const [showSummary, setShowSummary] = useState(false);
   const [importData, setImportData] = useState<ImportResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
+  const [parsedData, setParsedData] = useState<ParsedImportData | null>(null);
+  const [showPreview, setShowPreview] = useState(false);
+  const [fileName, setFileName] = useState<string | null>(null);
 
-  // Handle file input
+  // Handler for file selection and processing
   const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
 
-    const formData = new FormData();
-    formData.append("file", file);
+    setFileName(file.name);
 
-    // Reset states before new import
-    setError(null);
-    setSuccess(null);
-    setShowSummary(false);
-    setImportData(null);
-
-    // Send the file to the backend
     try {
-      const response = await fetch(`${import.meta.env.PUBLIC_API_BASE_URL}${endpoint}`, {
+      const formData = new FormData();
+      formData.append("file", file);
+
+      // Send the file to the preview endpoint before importing
+      const response = await fetch(`${import.meta.env.PUBLIC_API_BASE_URL}${endpoint.replace('/import-data', '/preview-import')}`, {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
+        headers: { Authorization: `Bearer ${token}` },
         body: formData,
       });
-      const data: ImportResponse = await response.json();
 
-      if (!response.ok || !data.success) {
-        // Mostrar el mensaje de error del backend
-        setError("Error al importar el archivo: " + (data.error || data.message));
-        setSuccess(null);
-        setImportData(null);
-        setShowSummary(false);
-      } else {
-        setImportData(data);
-        setShowSummary(true);
-        setError(null);
-        setSuccess("Archivo importado exitosamente: " + data.message);
-      }
-    } catch (error) {
-      setError(`Error al importar archivo: ${error instanceof Error ? error.message : "Desconocido"}`);
-      setSuccess(null);
-      setImportData(null);
+      const result = await response.json();
       setShowSummary(false);
+
+      if (!response.ok || !result.success) {
+        setError(result.error || "Error al procesar el archivo");
+        setParsedData(null);
+        setShowPreview(false);
+        return;
+      }
+
+      // Map the preview data to the format expected
+      const previewData: ParsedImportData = {
+        Empleados: result.preview.employees.map((emp: any) => ({
+          NoEmpleado: emp.employee_code,
+          Nombre: emp.full_name,
+          Usuario: emp.user_name,
+          Email: emp.email,
+          JefeInmediato: emp.boss_user,
+          Proveedor: emp.supplier,
+          CeCo: emp.cost_center_code,
+          Departamento: emp.department_clave,
+          Status: emp.active ? 'A' : 'I',
+          Rol: emp.role,
+        })),
+        Departamentos: result.preview.departments.map((dept: any) => ({
+          Clave: dept.department_clave,
+          Descripcion: dept.department_name,
+          CeCo: dept.cost_center_code,
+        })),
+        CeCo: result.preview.costCenters.map((cc: any) => ({
+          Clave: cc.cost_center_code,
+          Descripcion: cc.cost_center_name,
+        })),
+      };
+
+      setParsedData(previewData);
+      setShowPreview(true);
+      setError(null);
+    } catch (err) {
+      setError("Error al procesar el archivo: " + (err instanceof Error ? err.message : "Desconocido"));
+      setParsedData(null);
+      setShowPreview(false);
     }
+  };
+
+  // Handler for successful import, which updates the state to show the summary and any success message
+  const handleImportSuccess = (result: ImportResponse) => {
+    setShowPreview(false);
+    setParsedData(null);
+    setImportData(result);
+    setShowSummary(true);
+    setError(null);
+    setSuccess("Datos importados exitosamente");
   };
 
   return (
     <div className="space-y-4">
-      {/* Error message */}
-      {error && (
-        <Reminder type="warning" text={error} />
-      )}
-      {/* Acceptance message */}
-      {success && (
-        <Reminder type="success" text={success} />
-      )}
-      {/* Import data button */}
-      <Button
-        variant="filled"
-        color="secondary"
-        onClick={() => document.getElementById("fileInput")?.click()}
-      >
-        <div className="flex items-center gap-2">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="size-4">
-            <path d="M7.25 10.25a.75.75 0 0 0 1.5 0V4.56l2.22 2.22a.75.75 0 1 0 1.06-1.06l-3.5-3.5a.75.75 0 0 0-1.06 0l-3.5 3.5a.75.75 0 0 0 1.06 1.06l2.22-2.22v5.69Z" />
-            <path d="M3.5 9.75a.75.75 0 0 0-1.5 0v1.5A2.75 2.75 0 0 0 4.75 14h6.5A2.75 2.75 0 0 0 14 11.25v-1.5a.75.75 0 0 0-1.5 0v1.5c0 .69-.56 1.25-1.25 1.25h-6.5c-.69 0-1.25-.56-1.25-1.25v-1.5Z" />
-          </svg>
-          Subir archivo JSON
+      {error && <Reminder type="warning" text={error} />}
+      {success && <Reminder type="success" text={success} />}
+      {/* File Input */}
+      <div className="relative flex p-2 border-2 border-dashed border-border rounded-lg cursor-pointer">
+        <input
+          ref={fileInputRef}
+          type="file"
+          id="fileInput"
+          accept=".json"
+          onChange={handleFile}
+          className="absolute inset-0 opacity-0 cursor-pointer"
+        />
+        <div className="p-4 w-full h-full flex flex-col items-center">
+          <Icon name="upload" className="text-text-secondary" />
+          <span className="text-text-secondary pointer-events-none">
+            Selecciona un archivo JSON o arrastralo aquí
+          </span>
+          <p className="text-text-secondary text-sm">
+            {fileName? `${fileName}` : "Ningún archivo seleccionado"}
+          </p>
         </div>
-      </Button>
-      <input
-        type="file"
-        id="fileInput"
-        accept=".json"
-        className="hidden"
-        onChange={handleFile}
-      />
-      {/* Summary of import results */}
+      </div>
+      {/* Import Preview */}
+      {showPreview && parsedData && (
+        <ImportPreview
+          data={parsedData}
+          endpoint={endpoint}
+          token={token}
+          onClose={() => {
+            if (fileInputRef.current) fileInputRef.current.value = "";
+            setFileName(null);
+            setShowPreview(false);
+            setParsedData(null);
+          }}
+          onImportSuccess={handleImportSuccess}
+        />
+      )}
+      {/* Import Summary */}
       {showSummary && importData && importData.summary && (
         <div>
           <h2 className="text-xl font-semibold mb-4">Resumen de Importación</h2>
           <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4">
-            {/* Users */}
             <SummaryCard title="Usuarios">
               <SummaryItem
                 label="Creados"
@@ -196,13 +283,7 @@ export default function ImportDataButton({ endpoint, token }: Props) {
                 items={importData.summary.users.skipped}
                 type="warning"
               />
-              <SummaryItem
-                label="Desactivados"
-                items={importData.summary.users.deactivated}
-                type="warning"
-              />
             </SummaryCard>
-            {/* Departments */}
             <SummaryCard title="Departamentos">
               <SummaryItem
                 label="Creados"
@@ -220,7 +301,6 @@ export default function ImportDataButton({ endpoint, token }: Props) {
                 type="warning"
               />
             </SummaryCard>
-            {/* Cost Centers */}
             <SummaryCard title="Centros de Costo">
               <SummaryItem
                 label="Creados"

--- a/src/components/Forms/ImportDataForm.tsx
+++ b/src/components/Forms/ImportDataForm.tsx
@@ -4,7 +4,10 @@
 * This component provides a form for administrators to upload an organizational structure XML file.
 */
 
+import { useState } from "react";
 import ImportDataButton from "@/components/Buttons/ImportDataButton";
+import Icon from "@/components/Utils/Icon";
+import Button from "../Buttons/Button";
 
 // Example JSON structure
 const exampleJson =
@@ -72,6 +75,33 @@ type Props = {
  * @param {token} - The authentication token to authorize the API request.
  */
 export default function ImportDataForm({ endpoint, token }: Props) {
+  const [openExample, setOpenExample] = useState(false);
+
+  // Download example JSON file
+  const downloadExample = () => {
+    // A blob (binary large object) is used to 
+    // create a downloadable file from the example JSON string.
+    // Ref: https://developer.mozilla.org/es/docs/Web/API/Blob
+    const blob = new Blob([exampleJson], { type: 'application/json' });
+
+    // url is created for the blob
+    const url = URL.createObjectURL(blob);
+
+    // A temporary link element is created to trigger the download of the file when clicked.
+    const link = document.createElement('a');
+
+    link.href = url;
+    link.download = 'organigrama.json';
+    document.body.appendChild(link);
+
+    // Click the link to start the donwload
+    link.click();
+
+    // Clean up the URL and remove the temporary link element after the download is triggered.
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
   return (
     <div className="flex flex-col gap-8">
       <div className="card">
@@ -89,9 +119,31 @@ export default function ImportDataForm({ endpoint, token }: Props) {
           <h2>Formato esperado</h2>
           <p>El archivo JSON debe seguir la siguiente estructura</p>
         </div>
-        <pre className="card-secondary overflow-x-scroll">
-          {exampleJson}
-        </pre>
+        <button
+          className="flex w-full p-2 bg-secondary hover:opacity-80 hover:cursor-pointer rounded-md justify-center"
+          onClick={() => setOpenExample(!openExample)}
+        >
+          <div className="flex gap-2 items-center justify-center">
+            <p className="text-white font-medium">Ver ejemplo de formato</p>
+            <Icon name={openExample ? 'expand_less' : 'expand_more'} className="text-white" />
+          </div>
+        </button>
+        {openExample && (
+          <div className="relative">
+            <Button
+              variant="filled"
+              color="secondary"
+              size="small"
+              onClick={downloadExample}
+              className="absolute top-4 right-4 z-10"
+            >
+              Descargar ejemplo
+            </Button>
+            <pre className="card-secondary overflow-x-scroll">
+              {exampleJson}
+            </pre>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/Modals/ImportPreview.tsx
+++ b/src/components/Modals/ImportPreview.tsx
@@ -1,0 +1,337 @@
+/**
+ * Import Preview
+ * 
+ * This component displays a preview of the employee data to be imported, 
+ * allowing administrators to review the organizational structure before confirming the import. 
+ * It also allows assigning roles to employees before importing.
+ */
+
+import { useState, useEffect } from "react";
+import Button from "@/components/Buttons/Button";
+import Reminder from "@/components/Utils/Reminder";
+import DataTable from "@/components/Table/DataTable";
+import Tag from "@/components/Utils/Tag";
+import Select from "@/components/Utils/Select";
+import { apiRequest } from "@/utils/apiClient";
+
+// Interfaces for the component props and data structures used in the import process
+
+interface EmpleadoRaw {
+  NoEmpleado: string;
+  Nombre: string;
+  Usuario: string;
+  Email: string;
+  JefeInmediato: string | null;
+  Proveedor: number;
+  CeCo: number;
+  Departamento: number;
+  Status: string;
+  Rol?: string;
+}
+
+interface DepartamentoRaw {
+  Clave: number;
+  Descripcion: string;
+  CeCo: number;
+}
+
+interface CeCoRaw {
+  Clave: number;
+  Descripcion: string;
+}
+
+interface ParsedImportData {
+  Empleados: EmpleadoRaw[];
+  Departamentos: DepartamentoRaw[];
+  CeCo: CeCoRaw[];
+}
+
+interface ImportResponse {
+  success: boolean;
+  message: string;
+  summary?: {
+    users: {
+      created: string[];
+      updated: string[];
+      deactivated: string[];
+      skipped: string[];
+    };
+    departments: {
+      created: string[];
+      updated: string[];
+      skipped: string[];
+    };
+    costCenters: {
+      created: string[];
+      updated: string[];
+      skipped: string[];
+    };
+  };
+  error?: string;
+}
+
+interface Role {
+  role_id: number;
+  role_name: string;
+}
+
+interface Props {
+  data: ParsedImportData;
+  endpoint: string;
+  token: string;
+  onClose: () => void;
+  onImportSuccess: (result: ImportResponse) => void;
+}
+
+/**
+ * Import Preview Component
+ * Displays a preview of the data to employee data to be imported, 
+ * allowing the admin to review and assign roles before confirming the import.
+ * @param data - The parsed data containing employees, departments, and cost centers to be imported.
+ * @param {string} endpoint - The API endpoint to which the import request will be sent.
+ * @param {string} token - The authentication token for API requests.
+ * @param {function} onClose - Callback function to close the preview modal.
+ * @param {function} onImportSuccess - Callback function to handle successful import and display results.
+ */
+export default function ImportPreviewModal({
+  data,
+  endpoint,
+  token,
+  onClose,
+  onImportSuccess,
+}: Props) {
+  // States for managing active tab, role assignments, loading state, and errors
+  const [activeTab, setActiveTab] = useState<"empleados" | "departamentos" | "cecos">("empleados");
+  const [roleAssignments, setRoleAssignments] = useState<Record<string, string>>({});
+  const [roles, setRoles] = useState<Role[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [rolesLoading, setRolesLoading] = useState(true);
+
+  // Fetch available roles from the API
+  useEffect(() => {
+    apiRequest("/admin/get-roles", {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((rolesData) => {
+        setRoles(rolesData);
+        setRolesLoading(false);
+      })
+      .catch((error) => {
+        console.error("Error cargando roles:", error);
+        setError("No se pudieron cargar los roles.");
+        setRolesLoading(false);
+      });
+  }, [token]);
+
+  // Initialize role assignments based on the imported 
+  // data and available roles
+  useEffect(() => {
+    if (roles.length > 0) {
+      const initial: Record<string, string> = {};
+      data.Empleados.forEach((emp) => {
+        if (emp.Rol) {
+          // Find the role ID based on the role name in the imported data
+          const roleId = roles.find((r) => r.role_name === emp.Rol)?.role_id;
+          if (roleId) {
+            initial[emp.NoEmpleado] = String(roleId);
+          }
+        }
+      });
+      setRoleAssignments(initial);
+    }
+  }, [roles, data.Empleados]);
+
+  // Handler for confirming the import, which sends the 
+  // modified data with role assignments to the API
+  const handleImport = async () => {
+    setLoading(true);
+    setError(null);
+
+    const modifiedData = {
+      Empleados: data.Empleados.map((emp) => {
+        // Get the current role value from the preview (either changed or original)
+        const currentRoleId = roleAssignments[emp.NoEmpleado] ?? (emp.Rol ? String(roles.find((r) => r.role_name === emp.Rol)?.role_id ?? "") : "");
+        return {
+          NoEmpleado: emp.NoEmpleado,
+          Nombre: emp.Nombre,
+          Usuario: emp.Usuario,
+          Email: emp.Email,
+          JefeInmediato: emp.JefeInmediato,
+          Proveedor: emp.Proveedor,
+          CeCo: emp.CeCo,
+          Departamento: emp.Departamento,
+          Status: emp.Status,
+          Rol: currentRoleId || undefined,
+        };
+      }),
+      Departamentos: data.Departamentos.map(({ Clave, Descripcion, CeCo }) => ({
+        Clave,
+        Descripcion,
+        CeCo,
+      })),
+      CeCo: data.CeCo.map(({ Clave, Descripcion }) => ({
+        Clave,
+        Descripcion,
+      })),
+    };
+
+    // Create a blob from the modified data and send it as a file in a FormData object to the API
+    const blob = new Blob([JSON.stringify(modifiedData)], { type: "application/json" });
+    const formData = new FormData();
+    formData.append("file", blob, "organigrama.json");
+
+    try {
+      const res = await fetch(`${import.meta.env.PUBLIC_API_BASE_URL}${endpoint}`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+        body: formData,
+      });
+      const result: ImportResponse = await res.json();
+      if (!result.success) throw new Error(result.error ?? result.message);
+      onImportSuccess(result);
+    } catch (err: any) {
+      setError(err.message ?? "Error al importar");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Handler for role changes in the select dropdown
+  const handleRoleChange = (noEmpleado: string, roleId: string) => {
+    setRoleAssignments((prev) => ({
+      ...prev,
+      [noEmpleado]: roleId,
+    }));
+  };
+
+  // Filter out the superadmin role
+  const selectableRoles = roles.filter((r) => r.role_name !== "Superadministrador");
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Title */}
+      <h2 className="text-lg font-semibold">Vista previa de importación</h2>
+
+      {/* Error Message */}
+      {error && <Reminder type="warning" text={error} />}
+
+      {/* Tabs for switching between employees, departments, and cost centers */}
+      <div className="flex gap-2 mb-4">
+        {[
+          { id: "empleados", label: `Empleados (${data.Empleados.length})` },
+          { id: "departamentos", label: `Departamentos (${data.Departamentos.length})` },
+          { id: "cecos", label: `Centros de Costo (${data.CeCo.length})` },
+        ].map((tab) => (
+          <Button
+            key={tab.id}
+            variant={activeTab === tab.id ? "filled" : "border"}
+            color="secondary"
+            size="small"
+            onClick={() => setActiveTab(tab.id as any)}
+            disabled={loading}
+          >
+            {tab.label}
+          </Button>
+        ))}
+      </div>
+      
+      {/* Data Table for the active tab */}
+      <div className="flex-1 overflow-y-auto">
+        {/* Employee table */}
+        {activeTab === "empleados" && (
+          <DataTable
+            columns={[
+              { key: "Usuario", label: "Usuario" },
+              { key: "Correo", label: "Correo" },
+              { key: "JefeInmediato", label: "Jefe Inmediato" },
+              { key: "Departamento", label: "Departamento" },
+              { key: "CentroCosto", label: "Centro de Costos" },
+              { key: "Status", label: "Status" },
+              { key: "rol", label: "Rol" },
+            ]}
+            rows={data.Empleados.map((emp: any) => ({
+              Usuario: emp.Usuario,
+              Correo: emp.Email,
+              JefeInmediato: emp.JefeInmediato || "N/A",
+              Departamento: emp.Departamento,
+              CentroCosto: emp.CeCo,
+              Status: (
+                <Tag
+                  text={emp.Status === 'A' ? "Activo" : "Inactivo"}
+                  type={emp.Status === 'A' ? "success" : "warning"}
+                  size="small"
+                />
+              ),
+              rol: (
+                <Select
+                  label=""
+                  value={roleAssignments[emp.NoEmpleado] ?? (emp.Rol ? String(roles.find((r) => r.role_name === emp.Rol)?.role_id ?? "") : "")}
+                  name={`rol-${emp.NoEmpleado}`}
+                  onChange={(e) => handleRoleChange(emp.NoEmpleado, e.target.value)}
+                  disabled={rolesLoading || loading}
+                >
+                  <option value="">--- Asignar rol ---</option>
+                  {selectableRoles.map((role) => (
+                    <option key={role.role_id} value={String(role.role_id)}>
+                      {role.role_name}
+                    </option>
+                  ))}
+                </Select>
+              ),
+            }))}
+          />
+        )}
+
+        {/* Department table */}
+        {activeTab === "departamentos" && (
+          <DataTable
+            columns={[
+              { key: "Clave", label: "Clave" },
+              { key: "Descripcion", label: "Descripción" },
+              { key: "CeCo", label: "Centro de Costo" },
+            ]}
+            rows={data.Departamentos.map((dept) => ({
+              Clave: dept.Clave,
+              Descripcion: dept.Descripcion,
+              CeCo: dept.CeCo,
+            }))}
+          />
+        )}
+
+        {/* Cost Center table */}
+        {activeTab === "cecos" && (
+          <DataTable
+            columns={[
+              { key: "Clave", label: "Clave" },
+              { key: "Descripcion", label: "Descripción" },
+            ]}
+            rows={data.CeCo.map((ceco) => ({
+              Clave: ceco.Clave,
+              Descripcion: ceco.Descripcion,
+            }))}
+          />
+        )}
+      </div>
+
+      <div className="flex gap-2 justify-end">
+        <Button
+          variant="filled"
+          color="primary"
+          onClick={onClose}
+          disabled={loading}
+        >
+          Cancelar
+        </Button>
+        <Button
+          variant="filled"
+          color="secondary"
+          onClick={handleImport}
+          disabled={loading || rolesLoading}
+        >
+          {loading ? "Importando..." : "Importar Datos"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Table/BitacoraTable.tsx
+++ b/src/components/Table/BitacoraTable.tsx
@@ -96,7 +96,7 @@ const COLUMNS = [
 ];
 
 // Limit of entries per page
-const LIMIT = 50;
+const LIMIT = 20;
 
 // Helpers
 function formatDate(isoString: string): string {
@@ -206,7 +206,7 @@ export default function BitacoraTable({
   return (
     <div>
       {/* Filters */}
-      <div className="flex flex-col md:flex-row gap-3 items-end mb-8">
+      <div className="flex flex-col md:flex-row gap-3 items-end mb-2">
         {societyGroups.length > 0 ? (
           <div className="w-full md:flex-1 [&>div]:mb-0">
             <Select
@@ -249,11 +249,11 @@ export default function BitacoraTable({
             onChange={(e) => setFilterName(e.target.value)}
           />
         </div>
-
-        <span className="text-sm text-text-secondary md:ml-10 md:whitespace-nowrap">
-          {rows.length} resultado{rows.length === 1 ? "" : "s"} en esta página
-        </span>
       </div>
+
+      <span className="text-sm text-text-secondary md:whitespace-nowrap">
+        Mostrando {rows.length} de {meta.total_count} resultados
+      </span>
 
       {/* Error */}
       {error && (


### PR DESCRIPTION
<!-- -----------------------------------------------------------------
Pull Request Template

Select the type of PR below and complete the relevant checklist.
------------------------------------------------------------------ -->

# Pull Request Type

Select one (required):

- [x] **Feature** - New functionality or User Story implementation
- [ ] **Chore** - Maintenance, refactoring, docs, or tooling
- [ ] **Hotfix** - Critical bug fix for production
- [ ] **Documentation** - Documentation-only changes
- [ ] **Style** - Code formatting or linting with no functional change

---

**Description of feature:**

_What does this PR implement?_

### Import Employee Data Preview

- Added a preview step before final import: When a file is selected, its contents are sent to a `/preview-import` endpoint, and the parsed data is shown in an `ImportPreview` modal. This allows admin users to review the data before confirming the import. (`src/components/Buttons/ImportDataButton.tsx`)

- Replaced the standard file input and button with a drag-and-drop styled area.

- Added a collapsible section in the import form to display an example JSON structure, with a "Download Example" button that generates and downloads a sample file for users.

---

## Pre-Submission Checklist (All PRs)

- [x] I have read the [CONTRIBUTING](../../CONTRIBUTING.md) guide
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] PR targets the appropriate branch (`main` on dittravel)
- [x] Code has been tested locally
- [x]  No console errors or warnings
